### PR TITLE
DD-18: udpated the skaffold-build workflow to also push build-artifac…

### DIFF
--- a/.github/workflows/skaffold-build.yml
+++ b/.github/workflows/skaffold-build.yml
@@ -6,20 +6,32 @@ on:
       build-prerelease:
         required: true
         type: boolean
+      releases-repo:
+        default: cyverse-de/de-releases
+        type: string
     secrets:
       harbor-username:
         required: true
       harbor-password:
         required: true
+      releases-repo-push-token:
+        required: false
 
 jobs:
   pipeline:
     name: Skaffold Docker build
     runs-on: ubuntu-22.04
     steps:
+    - name: Set Environment
+      run: |
+        echo "REPO_NAME=${GITHUB_REPOSITORY/#*\//}" >> "${GITHUB_ENV}"
+
     - name: Checkout Repo
       id: checkout
       uses: actions/checkout@v4
+      with:
+        path: "${{env.REPO_NAME}}"
+
     - name: Harbor Login
       id: harbor_login
       uses: docker/login-action@v3
@@ -27,18 +39,46 @@ jobs:
         registry: harbor.cyverse.org
         username: ${{ secrets.harbor-username }}
         password: ${{ secrets.harbor-password }}
+
     - name: Install Kubernetes Tools
       id: install_k8s_tools
       uses: yokawasa/action-setup-kube-tools@v0.11.0
+
     - name: Build Docker images
       id: build
       run: |
+        cd "${REPO_NAME}"
         skaffold build --file-output build.json
+
     - name: Build manifest tarball
       id: build_manifest_tarball
       run: |
+        cd "${REPO_NAME}"
         tar -czpvf deploy-info.tar.gz build.json skaffold.yaml k8s
-    - uses: ncipollo/release-action@v1
+
+    - name: Create the Release
+      uses: ncipollo/release-action@v1
       with:
-        artifacts: "build.json,deploy-info.tar.gz"
+        artifacts: "${{ env.REPO_NAME }}/build.json,${{ env.REPO_NAME }}/deploy-info.tar.gz"
         prerelease: ${{ inputs.build-prerelease }}
+
+    - name: Pull the Releases Repository
+      if: ${{ secrets.releases-repo-push-token != '' }}
+      uses: actions/checkout@v4
+      with:
+        repository: ${{ inputs.releases-repo }}
+        path: releases
+        token: ${{ secrets.releases-repo-push-token }}
+
+    - name: Copy the Artifacts
+      if: ${{ secrets.releases-repo-push-token != '' }}
+      run: |
+        cd releases
+        git config user.name "GitHub Actions Bot"
+        git config user.email "<>"
+        mkdir -p builds "services/${REPO_NAME}"
+        cp "../${REPO_NAME}/build.json" "builds/${REPO_NAME}.json"
+        cp -pr "../${REPO_NAME}/skaffold.yaml" "../${REPO_NAME}/k8s" "services/${REPO_NAME}"
+        git add "builds/${REPO_NAME}.json" "services/${REPO_NAME}"
+        git commit -m "updated the build artifacts for ${REPO_NAME}"
+        git push


### PR DESCRIPTION
…ts to a release tracking repository

I'd originally planned to create a separate shared workflow to grab release artifacts and copy them to the `de-releases` repository, but this was easier.
