### PR TITLE
standardized runner to ubuntu-latest and bumped golangci-lint default

### DIFF
--- a/.github/workflows/go-build.yml
+++ b/.github/workflows/go-build.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   pipeline:
     name: Build Go Executable
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Set Environment
       run: |

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       golangci-lint-version:
-        default: v2.5.0
+        default: v2.12.2
         type: string
 
 permissions:

--- a/.github/workflows/skaffold-build.yml
+++ b/.github/workflows/skaffold-build.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   pipeline:
     name: Skaffold Docker build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set Environment
         run: |


### PR DESCRIPTION
Switched go-build and skaffold-build from ubuntu-22.04 to ubuntu-latest to match docker-build and golangci-lint, and bumped the default golangci-lint version from v2.5.0 to v2.12.2.